### PR TITLE
Version 1.9.8 – Fixes & improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ WordPress weather plugin displaying current conditions and optional daily foreca
 
 For common questions and troubleshooting see the FAQ: [FAQ.md](FAQ.md)
 
-**Version:** 1.9.7 (Experimental: tide/tidvatten support added for testing)
+**Version:** 1.9.8 Fixed an issue where the Leaflet map could fail to load on live/optimized sites due to script handle conflicts with themes or other plugins.
 
 ## Changelog
+
+###  1.9.8 (Current)
+- **Fixed:** Fixed an issue where the Leaflet map could fail to load on live/optimized sites due to script handle conflicts with themes or other plugins.
+- **Improved:** Renamed Leaflet asset handles to unique, plugin-specific names to prevent collisions and ensure correct dependency resolution.
+- **Improved:** Removed forced defer handling for Leaflet/map scripts to avoid broken load order when caching/optimization plugins are active.
+- **Improved:** Improved map initialization logic to prevent infinite retry loops and reduce console spam when Leaflet isn’t available.
+- **Improved:** Kept Leaflet/map assets conditionally loaded only on pages where the widget/block/shortcode is actually rendered.
 
 ### v1.9.7 (2026-01-30)
  - **Experimental:** Tide (tidvatten) support added for testing — opt-in feature. Adds support for WorldTides (API key), NOAA (US-only), and a configurable custom endpoint. Shortcode support via `extras="tides"` or `tides="1"`. Admin visibility can be toggled while rolling out to selected users. Responses are cached; configure TTL in Settings.
@@ -17,6 +24,7 @@ For common questions and troubleshooting see the FAQ: [FAQ.md](FAQ.md)
 - Eliminates unnecessary 404 errors on pages without weather widget
 - Added `.htaccess` files to ensure correct MIME types for static assets
 - Improved page load performance by reducing asset requests on non-weather pages
+- If the map loads in staging but not in production: exclude the plugin’s Leaflet/map scripts from “Delay JS” / “Defer JS” features in your cache/optimization plugin.
 
 ### Settings Page Speed
 - **Before:** 3-15 seconds (waiting for WP.org plugin showcase)
@@ -218,7 +226,15 @@ Translations are available on [translate.wordpress.org](https://translate.wordpr
 
 ## Version History
 
-### v1.9.7 (Current)
+###  1.9.8 (Current)
+- **Fixed:** Fixed an issue where the Leaflet map could fail to load on live/optimized sites due to script handle conflicts with themes or other plugins.
+- **Improved:** Renamed Leaflet asset handles to unique, plugin-specific names to prevent collisions and ensure correct dependency resolution.
+- **Improved:** Removed forced defer handling for Leaflet/map scripts to avoid broken load order when caching/optimization plugins are active.
+- **Improved:** Improved map initialization logic to prevent infinite retry loops and reduce console spam when Leaflet isn’t available.
+- **Improved:** Kept Leaflet/map assets conditionally loaded only on pages where the widget/block/shortcode is actually rendered.
+
+
+### v1.9.7 
  - **Experimental:** Tide support added for testing — opt-in feature. Adds support for WorldTides (API key), NOAA (US-only), and a configurable custom endpoint. Shortcode support via `extras="tides"` or `tides="1"`. Admin visibility can be toggled while rolling out to selected users. Responses are cached; configure TTL in Settings.
 
 ### 1.9.5

--- a/assets/map.js
+++ b/assets/map.js
@@ -31,13 +31,23 @@
   // --- Initialize maps WITHOUT a marker ---
   function initMap(el){
     if (el.dataset.inited) return;
+
+    // Retry guard (prevents infinite console spam if Leaflet never loads)
+    const tries = parseInt(el.dataset.svvLeafletTries || '0', 10);
+    if (tries > 20) { // ~10s total with 500ms interval
+      console.error('Leaflet failed to load after multiple retries. Giving up for element:', el);
+      el.dataset.svvLeafletFailed = '1';
+      el.dataset.inited = '1'; // lock
+      return;
+    }
+
     el.dataset.inited = '1';
 
     // Check if Leaflet is loaded
     if (typeof L === 'undefined' || !L.map) {
       console.warn('Leaflet not loaded yet, retrying...', el);
-      // Try again in a moment
       setTimeout(() => {
+        el.dataset.svvLeafletTries = String(tries + 1);
         delete el.dataset.inited;
         initMap(el);
       }, 500);
@@ -69,7 +79,6 @@
       map.setView([lat, lon], 12);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom:19 }).addTo(map);
 
-      // NOTE: No L.marker here — the pin is never placed.
       setTimeout(()=>map.invalidateSize(), 200);
     } catch (e) {
       console.error('Error initializing map:', e);
@@ -82,7 +91,6 @@
     const maps = Array.from(document.querySelectorAll('.svv-map'));
     if (!maps.length) return;
 
-    // If IntersectionObserver supported, observe and init when visible
     if ('IntersectionObserver' in window) {
       const io = new IntersectionObserver(function(entries){
         entries.forEach(function(entry){
@@ -94,14 +102,12 @@
       }, { root: null, rootMargin: '200px', threshold: 0.01 });
 
       maps.forEach(function(m){
-        // If already inited, skip
         if (m.dataset.inited) return;
         io.observe(m);
       });
       return;
     }
 
-    // Fallback: initialize immediately (keeps previous behavior)
     maps.forEach(initMap);
   }
 
@@ -115,7 +121,6 @@
   const attachRO = debounce(function(){
     if (!('ResizeObserver' in window)) return;
 
-    // Support both old (.sv-vader) and new (.spelhubben-weather) container classes
     document.querySelectorAll('.sv-vader[data-svv-ro="1"], .spelhubben-weather[data-svv-ro="1"]').forEach(function(card){
       if (card._svvObserved) return;
       card._svvObserved = true;
@@ -135,8 +140,7 @@
       applyScale();
       const ro = new ResizeObserver(debounce(applyScale, 60));
       ro.observe(card);
-      
-      // Store observer reference for cleanup
+
       card._svvResizeObserver = ro;
     });
   }, 50);
@@ -145,13 +149,11 @@
     document.addEventListener('DOMContentLoaded', attachRO);
   } else { attachRO(); }
 
-  // Single persistent MutationObserver instead of creating new ones
   const mutationObserver = new MutationObserver(function(mutations){
-    // Cleanup removed cards
     mutations.forEach(function(m){
       if (m.removedNodes.length) {
         m.removedNodes.forEach(function(node){
-          if (node.nodeType === 1) { // Element node
+          if (node.nodeType === 1) {
             const cards = node.querySelectorAll ? node.querySelectorAll('.sv-vader[data-svv-ro="1"], .spelhubben-weather[data-svv-ro="1"]') : [];
             cards.forEach(function(card){
               if (card._svvResizeObserver) {
@@ -170,6 +172,6 @@
     });
     attachRO();
   });
-  
+
   mutationObserver.observe(document.documentElement, { childList:true, subtree: true });
 })();

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -6,30 +6,42 @@ class SV_Vader_Assets {
 
     /**
      * Enqueue public-facing assets (CSS/JS) for the frontend.
-     * Only loads core stylesheet; Leaflet/map assets are loaded conditionally via filters.
+     * Only loads core stylesheet; Leaflet/map assets are loaded conditionally.
      */
     public function enqueue_public_assets() {
+
         // Core plugin stylesheet - register, enqueue only when used on the page
         // Prefer minified file when present and WP_DEBUG is not enabled
         $style_file = 'assets/style.css';
-        $base_dir = defined('SV_VADER_PATH') ? rtrim(SV_VADER_PATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR : dirname(__DIR__) . DIRECTORY_SEPARATOR;
+        $base_dir = defined('SV_VADER_PATH')
+            ? rtrim(SV_VADER_PATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+            : dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
         if ( ! ( defined('WP_DEBUG') && WP_DEBUG ) ) {
             if ( file_exists( $base_dir . 'assets' . DIRECTORY_SEPARATOR . 'style.min.css' ) ) {
                 $style_file = 'assets/style.min.css';
             }
         }
+
         wp_register_style('sv-vader-style', SV_VADER_URL . $style_file, [], SV_VADER_VER);
 
-        // Register Leaflet and map assets but don't auto-enqueue
-        // They will be enqueued conditionally via has_shortcode() or block detection
-        wp_register_style('leaflet-css', SV_VADER_URL . 'assets/vendor/leaflet/leaflet.css', [], '1.9.4');
-        wp_register_script('leaflet-js', SV_VADER_URL . 'assets/vendor/leaflet/leaflet.js', [], '1.9.4', true);
+        /**
+         * IMPORTANT:
+         * Use unique handles for Leaflet to avoid collisions with themes/other plugins.
+         * Live sites often already register "leaflet-js" which can break our dependency chain.
+         */
+        wp_register_style('svv-leaflet-css', SV_VADER_URL . 'assets/vendor/leaflet/leaflet.css', [], '1.9.4');
+        wp_register_script('svv-leaflet-js', SV_VADER_URL . 'assets/vendor/leaflet/leaflet.js', [], '1.9.4', true);
+
         // Prefer minified map script when available
         $map_file = 'assets/map.js';
         if ( ! ( defined('WP_DEBUG') && WP_DEBUG ) && file_exists( $base_dir . 'assets' . DIRECTORY_SEPARATOR . 'map.min.js' ) ) {
             $map_file = 'assets/map.min.js';
         }
-        wp_register_script('sv-vader-map', SV_VADER_URL . $map_file, ['leaflet-js'], SV_VADER_VER, true);
+
+        // Map depends on *our* Leaflet handle (svv-leaflet-js)
+        wp_register_script('sv-vader-map', SV_VADER_URL . $map_file, ['svv-leaflet-js'], SV_VADER_VER, true);
+
         // Small helper to rotate wind direction arrows when inline styles are stripped
         wp_register_script('sv-vader-wind', SV_VADER_URL . 'assets/wind.js', [], SV_VADER_VER, true);
 
@@ -39,12 +51,10 @@ class SV_Vader_Assets {
             wp_enqueue_script('sv-vader-wind');
         }
 
-        // Localized data for JS will be added only when the map script is enqueued
-
         // Load Leaflet assets only if shortcode is present or Gutenberg block is used
         if ( $this->should_load_leaflet() ) {
-            wp_enqueue_style('leaflet-css');
-            wp_enqueue_script('leaflet-js');
+            wp_enqueue_style('svv-leaflet-css');
+            wp_enqueue_script('svv-leaflet-js');
             wp_enqueue_script('sv-vader-map');
 
             // Localize only when map script is actually enqueued
@@ -52,8 +62,11 @@ class SV_Vader_Assets {
                 'iconBase' => trailingslashit(SV_VADER_URL . 'assets/vendor/leaflet/images'),
             ]);
 
-            // Add defer attribute to Leaflet/map to avoid render-blocking
-            add_filter('script_loader_tag', [$this, 'add_script_defer_attribute'], 10, 3);
+            /**
+             * NOTE:
+             * Do NOT force "defer" here. Defer/Delay/Async is best left to caching/optimization plugins,
+             * otherwise we risk Leaflet loading after our map script on some live setups.
+             */
         }
     }
 
@@ -61,7 +74,7 @@ class SV_Vader_Assets {
      * Check if Leaflet assets should be loaded on this page.
      */
     private function should_load_leaflet() {
-        global $post, $wp_registered_sidebars;
+        global $post;
 
         // Check for shortcodes in post content
         if ( isset( $post->post_content ) ) {
@@ -114,17 +127,5 @@ class SV_Vader_Assets {
         }
 
         return false;
-    }
-
-    /**
-     * Add 'defer' attribute for heavy frontend scripts so they don't block rendering.
-     */
-    public function add_script_defer_attribute($tag, $handle, $src) {
-        // Only defer these handles
-        $defer = ['leaflet-js', 'sv-vader-map'];
-        if ( in_array($handle, $defer, true) ) {
-            return str_replace(' src', ' defer src', $tag);
-        }
-        return $tag;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: weather, forecast, widget, shortcode, blocks
 Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.9.7
+Stable tag: 1.9.8
 Donate link: https://www.paypal.com/donate/?hosted_button_id=CV74CEXY5XEAU
 
 License: GPLv3 or later
@@ -91,7 +91,7 @@ If you're testing tide support in version 1.9.7:
 - **Troubleshooting:** Use `tests/tide_test.php` to validate provider responses and caching. Ensure provider settings and API key are correct; tide results are cached according to the configured TTL.
 
 If `lat` and `lon` are provided they take precedence. Otherwise the plugin geocodes the `place` string (e.g. `place="Umeå"`). Set a global default place in settings.
-
+rontend assets are registered
 = What fields can I show/hide? =
 Use `show="temp,wind,icon"` (comma separated). Defaults are set in settings. Add `wind_dir` to show wind direction arrow and label.
 
@@ -212,6 +212,13 @@ languages/
 6. Performance page: cache statistics, API usage and "Clear cache" action.
 
 == Changelog ==
+- = 1.9.8 =
+- **Fixed:** Fixed an issue where the Leaflet map could fail to load on live/optimized sites due to script handle conflicts with themes or other plugins.
+- **Improved:** Renamed Leaflet asset handles to unique, plugin-specific names to prevent collisions and ensure correct dependency resolution.
+- **Improved:** Removed forced defer handling for Leaflet/map scripts to avoid broken load order when caching/optimization plugins are active.
+- **Improved:** Improved map initialization logic to prevent infinite retry loops and reduce console spam when Leaflet isn’t available.
+- **Improved:** Kept Leaflet/map assets conditionally loaded only on pages where the widget/block/shortcode is actually rendered.
+
 - = 1.9.7 =
 - **Experimental:** Tide support added for testing — opt-in feature. Adds support for WorldTides (API key), NOAA (US-only), and a configurable custom endpoint. Shortcode support via `extras="tides"` or `tides="1"`. Admin visibility can be toggled while rolling out to selected users. Responses are cached; configure TTL in Settings.
 

--- a/spelhubben-weather.php
+++ b/spelhubben-weather.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Spelhubben Weather
  * Description: Displays current weather and an optional forecast with a simple consensus across providers (Open-Meteo, SMHI, Yr/MET Norway). Supports shortcode + Gutenberg block + classic widget. Optional Leaflet map, subtle animations, daily forecast, and multiple layouts.
- * Version: 1.9.7
+ * Version: 1.9.8
  * Author: Spelhubben
  * Text Domain: spelhubben-weather
  * Domain Path: /languages
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // ── Constants (kept for backward compatibility).
 	if ( ! defined( 'SV_VADER_VER' ) ) {
-		define( 'SV_VADER_VER', '1.9.7' );
+		define( 'SV_VADER_VER', '1.9.8' );
 	}
 if ( ! defined( 'SV_VADER_DIR' ) ) {
 	define( 'SV_VADER_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
- Fixed an issue where the Leaflet map could fail to load on live/optimized sites due to script handle conflicts with themes or other plugins.
- Renamed Leaflet asset handles to unique, plugin-specific names to prevent collisions and ensure correct dependency resolution.
- Removed forced defer handling for Leaflet/map scripts to avoid broken load order when caching/optimization plugins are active.
- Improved map initialization logic to prevent infinite retry loops and reduce console spam when Leaflet isn’t available.
- Kept Leaflet/map assets conditionally loaded only on pages where the widget/block/shortcode is actually rendered.